### PR TITLE
Add optional aarch64 cross compilation

### DIFF
--- a/c_preload_lib/Makefile
+++ b/c_preload_lib/Makefile
@@ -1,4 +1,9 @@
-CC ?= gcc
+###
+# Allow optional cross compilation by setting the CROSS_COMPILE variable.
+# When targeting aarch64, use `make CROSS_COMPILE=aarch64-linux-gnu-`.
+###
+CROSS_COMPILE ?=
+CC = $(CROSS_COMPILE)gcc
 CFLAGS ?= -O2 -fPIC -Wall -Wextra
 LDFLAGS ?= -shared -ldl
 TARGET := libi2c_redirect.so

--- a/c_preload_lib/README.md
+++ b/c_preload_lib/README.md
@@ -6,6 +6,11 @@ make
 # or: gcc -shared -fPIC -O2 -Wall -Wextra -o libi2c_redirect.so i2c_redirect.c -ldl
 ```
 
+Cross-compile for aarch64 (requires `aarch64-linux-gnu-gcc` on PATH):
+```bash
+make CROSS_COMPILE=aarch64-linux-gnu-
+```
+
 Run (tee mode):
 ```bash
 export I2C_PROXY_SOCK=/tmp/i2c.tap.sock

--- a/i2c_tap_server/README.md
+++ b/i2c_tap_server/README.md
@@ -6,6 +6,13 @@ cd i2c_tap_server
 cargo build --release
 ```
 
+Cross-compile for aarch64 (requires Rust target and linker):
+```bash
+cd i2c_tap_server
+rustup target add aarch64-unknown-linux-gnu # once
+CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc cargo build --release --target aarch64-unknown-linux-gnu
+```
+
 Run:
 ```bash
 ./target/release/i2c_tap_server /tmp/i2c.tap.sock


### PR DESCRIPTION
## Summary
- enable CROSS_COMPILE prefix in preload library Makefile
- document aarch64 cross-compilation steps for preload lib and tap server

## Testing
- `make -C c_preload_lib`
- `make -C c_preload_lib CROSS_COMPILE=aarch64-linux-gnu-`
- `cargo build --release --manifest-path i2c_tap_server/Cargo.toml`
- `cargo build --release --target aarch64-unknown-linux-gnu --manifest-path i2c_tap_server/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b8885981dc8332bd3c372c26561829