### PR TITLE
Add socat-based TTY bridge to preload library

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,17 @@ Remove build artifacts with:
 make clean
 ```
 
+## Serial forwarding with socat
+
+When using the `c_preload_lib` you can have it automatically start a
+`socat` process that bridges a Unix domain socket to a serial TTY. Configure
+the following environment variables before launching the target application:
+
+* `I2C_SOCAT_TTY` – path of the serial device (e.g. `/dev/ttyS22`).
+* `I2C_SOCAT_SOCKET` – Unix socket path for the `socat` listener. Defaults to
+  `/tmp/ttyS22.tap.sock` if unset.
+
+Set `I2C_PROXY_SOCK` to the same socket so the preload library connects to the
+bridge. The helper process is automatically terminated when the library is
+unloaded.
+

--- a/c_preload_lib/README.md
+++ b/c_preload_lib/README.md
@@ -26,3 +26,20 @@ unset I2C_PROXY_PASSTHROUGH
 export LD_PRELOAD=$PWD/libi2c_redirect.so
 your_i2c_program
 ```
+
+### Optional serial forwarding via socat
+
+The library can automatically spawn a `socat` process that bridges the proxy
+socket to a serial TTY.  Set `I2C_SOCAT_TTY` to the device path and point
+`I2C_PROXY_SOCK` at the same Unix socket used by the helper:
+
+```bash
+export I2C_SOCAT_TTY=/dev/ttyS22            # serial device to bridge
+export I2C_SOCAT_SOCKET=/tmp/ttyS22.tap.sock   # optional, defaults to /tmp/ttyS22.tap.sock
+export I2C_PROXY_SOCK=$I2C_SOCAT_SOCKET     # socket used by the preload library
+export LD_PRELOAD=$PWD/libi2c_redirect.so
+your_i2c_program
+```
+
+When the host process exits the preload library terminates the `socat`
+helper automatically.


### PR DESCRIPTION
## Summary
- launch optional `socat` helper when `I2C_SOCAT_TTY` is set
- clean up the spawned helper on library unload
- document new `I2C_SOCAT_TTY` and `I2C_SOCAT_SOCKET` variables
- default socat socket path now `/tmp/ttyS22.tap.sock`

## Testing
- `cd c_preload_lib && make clean && make`


------
https://chatgpt.com/codex/tasks/task_e_68b9abbbf1e48332bc34e4b4f56ebef0