### PR TITLE
Add environment setup scripts for tap servers

### DIFF
--- a/scripts/env_i2c_tap_no_passthrough.sh
+++ b/scripts/env_i2c_tap_no_passthrough.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Configure environment variables to route I²C traffic through the i2c tap
+# server without accessing any real hardware.
+#
+# The script should be sourced so that the exports affect the current shell.
+# It defines the following variables:
+#   I2C_PROXY_SOCK     - Unix socket used by the tap server (default: /tmp/i2c.tap.sock)
+#   LD_PRELOAD         - Path to the preload library that intercepts I²C calls
+# The variable I2C_PROXY_PASSTHROUGH is explicitly unset to prevent real bus
+# accesses.  After sourcing this file run the desired I²C program normally and
+# all calls will be forwarded to the tap server.
+
+# Use caller supplied socket path or fall back to the default.
+export I2C_PROXY_SOCK="${I2C_PROXY_SOCK:-/tmp/i2c.tap.sock}"
+# Ensure passthrough is disabled so no real I²C hardware is accessed.
+unset I2C_PROXY_PASSTHROUGH
+# Point LD_PRELOAD at the interception library located in the current
+# working directory.  If LD_PRELOAD is already set the existing value is
+# preserved; otherwise a relative path is used so the caller can position
+# the library as needed.
+export LD_PRELOAD="${LD_PRELOAD:-./libi2c_redirect.so}"
+
+# Provide a brief summary so users know the configuration in effect.
+echo "I2C tap environment configured:"
+echo "  I2C_PROXY_SOCK=$I2C_PROXY_SOCK"
+echo "  I2C_PROXY_PASSTHROUGH is unset"
+echo "  LD_PRELOAD=$LD_PRELOAD"
+

--- a/scripts/env_tty_tap_no_passthrough.sh
+++ b/scripts/env_tty_tap_no_passthrough.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Configure environment variables so the I²C redirect library forwards traffic
+# through a serial TTY tap server without touching real I²C hardware.
+#
+# This script should be sourced to modify the current shell environment.  It
+# sets:
+#   I2C_SOCAT_TTY      - Serial device to bridge (default: /dev/ttyS22)
+#   I2C_SOCAT_SOCKET   - Unix socket used by the socat helper
+#   I2C_PROXY_SOCK     - Socket the preload library connects to
+#   LD_PRELOAD         - Path to the preload library
+# It also unsets I2C_PROXY_PASSTHROUGH to prevent access to actual I²C buses.
+
+# Serial device used for tapping; override by pre-setting I2C_SOCAT_TTY.
+export I2C_SOCAT_TTY="${I2C_SOCAT_TTY:-/dev/ttyS22}"
+# Socket path for the socat bridge; default derives from device name.
+export I2C_SOCAT_SOCKET="${I2C_SOCAT_SOCKET:-/tmp/ttyS22.tap.sock}"
+# The preload library connects to the same socket exposed by socat.
+export I2C_PROXY_SOCK="$I2C_SOCAT_SOCKET"
+# Disable passthrough so intercepted calls never reach real I²C hardware.
+unset I2C_PROXY_PASSTHROUGH
+# Point LD_PRELOAD at the interception library located in the current
+# working directory.  Users may override LD_PRELOAD to supply a different
+# path but by default a relative path is used so this script functions in any
+# directory containing libi2c_redirect.so.
+export LD_PRELOAD="${LD_PRELOAD:-./libi2c_redirect.so}"
+
+# Provide a summary for the user.
+echo "TTY tap environment configured:"
+echo "  I2C_SOCAT_TTY=$I2C_SOCAT_TTY"
+echo "  I2C_SOCAT_SOCKET=$I2C_SOCAT_SOCKET"
+echo "  I2C_PROXY_SOCK=$I2C_PROXY_SOCK"
+echo "  I2C_PROXY_PASSTHROUGH is unset"
+echo "  LD_PRELOAD=$LD_PRELOAD"
+


### PR DESCRIPTION
## Summary
- add script to configure environment variables for i2c tap server without hardware passthrough
- add script to configure environment variables for tty tap server without hardware passthrough
- simplify env scripts to avoid repository-specific paths and assume `libi2c_redirect.so` is in the current directory

## Testing
- `shellcheck scripts/env_i2c_tap_no_passthrough.sh scripts/env_tty_tap_no_passthrough.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b9f26a41548332a77caed0c9860aeb