### PR TITLE
Replace i2c_tty_redirect with tty_tap_server in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains a collection of tools for intercepting and manipulating I²C traffic.  The project includes:
 
 - **c_preload_lib** – a shared library used to intercept I²C operations via LD_PRELOAD
-- **i2c_tty_redirect** – a helper that forwards I²C data to a serial port
+- **tty_tap_server** – a Rust server that listens on a serial TTY, logs each line, and echoes it back (with optional raw-frame support)
 - **i2c_tap_server** – a Rust server that streams captured bus data
 - **i2c_time_writer** – a Rust utility that inserts timing information into the I²C stream
 
@@ -15,7 +15,7 @@ The top-level `Makefile` builds all components in one step.  From the repository
 make
 ```
 
-This compiles the C preload library, `i2c_tty_redirect`, and both Rust utilities.
+This compiles the C preload library and the Rust utilities `tty_tap_server`, `i2c_tap_server`, and `i2c_time_writer`.
 
 ### Cross-compiling for aarch64
 


### PR DESCRIPTION
## Summary
- replace `i2c_tty_redirect` with `tty_tap_server` in the component list
- clarify build instructions to list all Rust utilities

## Testing
- `cargo test --manifest-path tty_tap_server/Cargo.toml`
- `cargo test --manifest-path i2c_tap_server/Cargo.toml`
- `cargo test --manifest-path i2c_time_writer/Cargo.toml`
- `make -C c_preload_lib`


------
https://chatgpt.com/codex/tasks/task_e_68b9f69d3e1c8332a9e3a8f38a832000