### PR TITLE
Use PTY link for socat helper

### DIFF
--- a/c_preload_lib/i2c_redirect.c
+++ b/c_preload_lib/i2c_redirect.c
@@ -160,8 +160,14 @@ static void spawn_socat(void) {
         char open_spec[512];
         snprintf(listen_spec, sizeof(listen_spec),
                  "UNIX-LISTEN:%s,fork,mode=777", socat_socket_path);
+        /*
+         * Use a PTY link so socat will create the pseudo terminal device if it
+         * does not already exist.  The 'link' option ensures the allocated pty
+         * is symlinked to the requested path, allowing the caller to open it
+         * even when the node was missing before the helper started.
+         */
         snprintf(open_spec, sizeof(open_spec),
-                 "OPEN:%s,raw,echo=0,b115200", socat_tty_path);
+                 "PTY,link=%s,raw,echo=0,b115200", socat_tty_path);
         /* Invoke socat from a fixed location so the correct helper is used. */
         execl(SOCAT_BINARY, "socat", listen_spec, open_spec, (char *)NULL);
         _exit(1); /* execl only returns on error */


### PR DESCRIPTION
## Summary
- Replace socat OPEN specification with PTY link so the helper can create the pseudo terminal when missing
- Document PTY usage within spawn_socat

## Testing
- `make clean && make` (in c_preload_lib)
- `make test` (fails: No rule to make target 'test')
- `clang-format -n --Werror c_preload_lib/i2c_redirect.c` (fails: code should be clang-formatted)


------
https://chatgpt.com/codex/tasks/task_e_68b9f86b973c8332a9d3c2919796527e