### PR TITLE
Create missing TTY node in tap environment script

### DIFF
--- a/scripts/env_tty_tap_no_passthrough.sh
+++ b/scripts/env_tty_tap_no_passthrough.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Configure environment variables so the I²C redirect library forwards traffic
-# through a serial TTY tap server without touching real I²C hardware.
+# through a serial TTY tap server without touching real I²C hardware.  The
+# script also ensures a usable serial device node is present by creating one
+# with `socat` when necessary.
 #
 # This script should be sourced to modify the current shell environment.  It
 # sets:
@@ -8,10 +10,26 @@
 #   I2C_SOCAT_SOCKET   - Unix socket used by the socat helper
 #   I2C_PROXY_SOCK     - Socket the preload library connects to
 #   LD_PRELOAD         - Path to the preload library
-# It also unsets I2C_PROXY_PASSTHROUGH to prevent access to actual I²C buses.
+# If the chosen serial device does not exist a background `socat` process is
+# started to create it.  The script also unsets I2C_PROXY_PASSTHROUGH to
+# prevent access to actual I²C buses.
 
 # Serial device used for tapping; override by pre-setting I2C_SOCAT_TTY.
 export I2C_SOCAT_TTY="${I2C_SOCAT_TTY:-/dev/ttyS22}"
+# If the requested serial device is absent create a pseudo terminal so the tap
+# server has something to open.  When `socat` is missing a warning is printed
+# and the user must create the device manually.
+if [[ ! -e "$I2C_SOCAT_TTY" ]]; then
+  if command -v socat >/dev/null 2>&1; then
+    socat pty,link="$I2C_SOCAT_TTY",raw,echo=0 >/dev/null 2>&1 &
+    I2C_SOCAT_TTY_STATUS="created"
+  else
+    echo "Warning: $I2C_SOCAT_TTY does not exist and socat is not installed" >&2
+    I2C_SOCAT_TTY_STATUS="missing; socat unavailable"
+  fi
+else
+  I2C_SOCAT_TTY_STATUS="exists"
+fi
 # Socket path for the socat bridge; default derives from device name.
 export I2C_SOCAT_SOCKET="${I2C_SOCAT_SOCKET:-/tmp/ttyS22.tap.sock}"
 # The preload library connects to the same socket exposed by socat.
@@ -26,7 +44,7 @@ export LD_PRELOAD="${LD_PRELOAD:-./libi2c_redirect.so}"
 
 # Provide a summary for the user.
 echo "TTY tap environment configured:"
-echo "  I2C_SOCAT_TTY=$I2C_SOCAT_TTY"
+echo "  I2C_SOCAT_TTY=$I2C_SOCAT_TTY ($I2C_SOCAT_TTY_STATUS)"
 echo "  I2C_SOCAT_SOCKET=$I2C_SOCAT_SOCKET"
 echo "  I2C_PROXY_SOCK=$I2C_PROXY_SOCK"
 echo "  I2C_PROXY_PASSTHROUGH is unset"


### PR DESCRIPTION
## Summary
- Ensure `env_tty_tap_no_passthrough.sh` verifies the serial device exists before use
- Spawn `socat` to create the TTY when absent and report status in user messages
- Document new behavior with detailed comments

## Testing
- `shellcheck scripts/env_tty_tap_no_passthrough.sh`
- `bash scripts/env_tty_tap_no_passthrough.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b9f86c4d608332a6337f49c479fd04