### PR TITLE
tty_tap_server: wait for device to be available

### DIFF
--- a/tty_tap_server/README.md
+++ b/tty_tap_server/README.md
@@ -1,7 +1,8 @@
 # tty_tap_server
 
-Simple serial tap server that listens on `/dev/ttyS22`, prints any lines
-received, and echoes each line back with an incrementing counter.
+Simple serial tap server that waits for `/dev/ttyS22` to become available,
+prints any lines received, and echoes each line back with an incrementing
+counter.
 
 When the environment variable `I2C_PROXY_RAW` is set to a non-zero value the
 server switches to raw mode. In this mode serial traffic is expected to be in


### PR DESCRIPTION
## Summary
- wait for /dev/ttyS22 before starting tty tap server
- document new wait behavior in README

## Testing
- `cargo test --manifest-path tty_tap_server/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b9fb1fe6248332a67be35b04565c0f