### PR TITLE
Use ASCII timestamps for tap server

### DIFF
--- a/i2c_time_writer/src/main.rs
+++ b/i2c_time_writer/src/main.rs
@@ -2,7 +2,7 @@ use libc::c_ulong;
 use std::{
     env,
     fs::OpenOptions,
-    io::{Read, Write},
+    io::{BufRead, BufReader, Write},
     os::fd::AsRawFd,
     thread::sleep,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -12,10 +12,9 @@ use std::{
 const I2C_SLAVE: c_ulong = 0x0703;
 
 // Periodically write the current UNIX time to the specified I²C device
-// address. The timestamp is transmitted as a little-endian `u64` so the
-// companion tap server can interpret the binary value directly. Using the raw
-// representation avoids the overhead of formatting ASCII strings and matches
-// the expectation of consumers that operate on native integers.
+// address. The timestamp is transmitted as a newline-terminated ASCII string
+// so the companion tap server can easily echo and display the value without
+// dealing with byte order or binary parsing.
 fn main() -> std::io::Result<()> {
     let args: Vec<String> = env::args().collect();
     if args.len() < 3 {
@@ -32,14 +31,18 @@ fn main() -> std::io::Result<()> {
     }
     .expect("invalid address");
 
-    // Open the I²C device and select the slave address.
-    let mut file = OpenOptions::new().read(true).write(true).open(dev_path)?;
+    // Open the I²C device and select the slave address. The file handle is
+    // cloned so that reads can be buffered independently from writes without
+    // disturbing the underlying seek position.
+    let file = OpenOptions::new().read(true).write(true).open(dev_path)?;
     let fd = file.as_raw_fd();
     unsafe {
         if libc::ioctl(fd, I2C_SLAVE, addr as c_ulong) < 0 {
             return Err(std::io::Error::last_os_error());
         }
     }
+    let mut reader = BufReader::new(file.try_clone()?);
+    let mut writer = file;
 
     // Every second, write the current timestamp to the device and then read
     // back a line of text. The companion tap server echoes the write and
@@ -50,64 +53,33 @@ fn main() -> std::io::Result<()> {
         let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
         let secs = now.as_secs();
 
-        // Encode the current time as a little-endian byte array. Sending the
-        // raw bytes keeps the wire format compact and unambiguous.
-        let bytes = secs.to_le_bytes();
+        // Format the current time as a newline-terminated ASCII string. Using
+        // text keeps the data human readable when inspecting logs and avoids
+        // endianness concerns on different architectures.
+        let line = format!("{}\n", secs);
 
-        // Write the 8-byte timestamp to the I²C device. `write_all` blocks until
-        // all bytes have been transmitted so the reader sees a complete value.
-        file.write_all(&bytes)?;
+        // Write the textual timestamp to the I²C device. `write_all` blocks
+        // until the entire buffer has been transmitted so the reader sees a
+        // complete line. Flushing prevents the data from lingering in userland
+        // buffers.
+        writer.write_all(line.as_bytes())?;
+        writer.flush()?;
 
-        // Collect bytes from the device until a newline terminator is seen.
-        // The response is expected to be ASCII and follow the pattern
-        // "<counter>: <value>". Reading byte by byte keeps the logic simple and
-        // avoids buffering more than necessary.
-        let mut raw = Vec::new();
-        loop {
-            let mut byte = [0u8; 1];
-            // Attempt to read a single byte from the I²C device. Using
-            // `read` instead of `read_exact` lets us gracefully handle short
-            // reads or transient I/O errors without terminating the program.
-            match file.read(&mut byte) {
-                // A return of zero can mean two different things depending on
-                // when it occurs. If no data has been received yet it likely
-                // indicates that the tap server has not responded and we
-                // should give up for this iteration. However, if some bytes
-                // were already read it simply means more data has not yet
-                // arrived. In that case wait briefly and try again so that
-                // the partially received line can be completed instead of
-                // being interpreted as an empty value.
-                Ok(0) => {
-                    if raw.is_empty() {
-                        eprintln!("no data available from device");
-                        break;
-                    } else {
-                        sleep(Duration::from_millis(10));
-                        continue;
-                    }
-                }
-                // Successfully read a byte; accumulate it unless it terminates
-                // the line. Guard against excessively long responses as before.
-                Ok(_) => {
-                    if byte[0] == b'\n' {
-                        break;
-                    }
-                    raw.push(byte[0]);
-                    if raw.len() > 128 {
-                        break;
-                    }
-                }
-                // Any error is reported but does not abort the entire program,
-                // allowing the writer to continue operating even if a single
-                // read fails.
-                Err(e) => {
-                    eprintln!("read error: {}", e);
-                    break;
-                }
+        // Block until a newline-terminated response is received. This ensures
+        // a strict request/response exchange so that no more than one
+        // timestamp is in flight at any given time.
+        let mut text = String::new();
+        match reader.read_line(&mut text) {
+            Ok(0) => {
+                eprintln!("no data available from device");
+                continue;
+            }
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!("read error: {}", e);
+                continue;
             }
         }
-
-        let text = String::from_utf8_lossy(&raw);
         if let Some((ctr, val)) = text.split_once(':') {
             let counter = ctr.trim().parse::<u64>().unwrap_or(0);
             let echoed = val.trim().parse::<u64>().unwrap_or(0);

--- a/tty_tap_server/src/main.rs
+++ b/tty_tap_server/src/main.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::fs::OpenOptions;
-use std::io::{self, BufReader, Read, Write};
+use std::io::{self, BufRead, BufReader, Read, Write};
 use std::path::Path;
 use std::thread;
 use std::time::Duration;
@@ -8,9 +8,9 @@ use std::time::Duration;
 /// Connect to `/dev/ttyS22`, log received messages, and optionally echo them
 /// back. When the `I2C_PROXY_RAW` environment variable is set to any value
 /// other than `0`, the program expects binary `[addr][cmd][len][data...]` frames
-/// and prints the full frame as a hexadecimal string. Otherwise it reads
-/// eight-byte little-endian timestamps, logging each value and echoing it back
-/// as a textual line with an incrementing counter.
+/// and prints the full frame as a hexadecimal string. Otherwise it treats the
+/// input as newline-delimited text, logging each line and echoing it back with
+/// an incrementing counter.
 fn main() -> io::Result<()> {
     // Path to the serial port that the server will interact with.
     let path = Path::new("/dev/ttyS22");
@@ -71,31 +71,24 @@ fn main() -> io::Result<()> {
             writer.flush()?;
         }
     } else {
-        // In text mode the connected writer sends raw `u64` timestamps. Clone
-        // the file descriptor so reading and writing can occur independently.
-        let mut reader = file.try_clone()?;
+        // In text mode the connected writer sends newline-delimited ASCII
+        // strings that represent timestamps.  Clone the file descriptor so that
+        // reads and writes operate on independent handles.
+        let reader = BufReader::new(file.try_clone()?);
         let mut writer = file;
         println!("Listening on {:?}...", path);
         let mut counter: u64 = 0;
 
-        loop {
-            // Attempt to read exactly eight bytes representing a little-endian
-            // `u64` of seconds since the UNIX epoch. Any unexpected EOF ends
-            // the loop while other errors are surfaced to the caller.
-            let mut buf = [0u8; 8];
-            if let Err(e) = reader.read_exact(&mut buf) {
-                if e.kind() != io::ErrorKind::UnexpectedEof {
-                    return Err(e);
-                }
-                break;
-            }
-            let secs = u64::from_le_bytes(buf);
-            println!("Received: {}", secs);
+        // Process each line as it arrives, logging it and echoing it back with
+        // an incrementing counter so the sender can correlate requests and
+        // responses.
+        for line in reader.lines() {
+            let line = line?;
+            if line.trim().is_empty() { continue; }
 
-            // Echo the timestamp back as an ASCII line that includes a
-            // monotonically increasing counter. The trailing newline matches
-            // the expectations of the I²C time writer's read loop.
-            let response = format!("{}: {}\n", counter, secs);
+            println!("Received: {}", line);
+
+            let response = format!("{}: {}\n", counter, line.trim());
             writer.write_all(response.as_bytes())?;
             writer.flush()?;
             counter += 1;


### PR DESCRIPTION
## Summary
- send UNIX time to I²C device as newline-delimited ASCII text
- read and echo ASCII lines in `tty_tap_server`
- block time writer until a full response line is received to avoid queued messages

## Testing
- `cd i2c_time_writer && cargo test`
- `cd tty_tap_server && cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ba02d58aa483328057c3dd41e680f1