### PR TITLE
Use binary replies for time packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains a collection of tools for intercepting and manipulating I²C traffic.  The project includes:
 
 - **c_preload_lib** – a shared library used to intercept I²C operations via LD_PRELOAD
-- **tty_tap_server** – a Rust server that listens on a serial TTY, logs each line, and echoes it back (with optional raw-frame support)
+- **tty_tap_server** – a Rust server that listens on a serial TTY, logs eight-byte timestamp packets, and echoes them back with a counter (with optional raw-frame support)
 - **i2c_tap_server** – a Rust server that streams captured bus data
 - **i2c_time_writer** – a Rust utility that inserts timing information into the I²C stream
 
@@ -72,7 +72,8 @@ I2C_PROXY_SOCK=/tmp/ttyS22.tap.sock \
 ./i2c_time_writer/target/release/i2c_time_writer /dev/i2c-1 0x50
 ```
 
-The time writer sends the current Unix timestamp once per second. The tap server
-logs each line and echoes it back with a counter, which the time writer prints
-to its standard output.
+The time writer sends the current Unix timestamp once per second as an
+eight-byte little-endian value. The tap server echoes the same bytes back and
+appends an eight-byte counter, which the time writer prints to its standard
+output.
 

--- a/i2c_time_writer/README.md
+++ b/i2c_time_writer/README.md
@@ -1,11 +1,11 @@
 # i2c_time_writer
 
 Example program that writes the current Unix time to an I²C device once per
-second.  The timestamp is sent as a decimal ASCII string terminated by a
-newline so that a companion tap server operating in line mode can echo the
-data back.  The program is intended to be used with the
-`libi2c_redirect.so` preload library so that all I²C operations are
-intercepted and logged.
+second. The timestamp is transmitted as an eight-byte little-endian binary
+`u64`, keeping the wire format compact and easy to parse. A companion tap
+server echoes the timestamp back and appends its own eight-byte counter. The
+program is intended to be used with the `libi2c_redirect.so` preload library so
+that all I²C operations are intercepted and logged.
 
 ## Build
 
@@ -26,7 +26,8 @@ I2C_PROXY_SOCK=/tmp/ttyS22.tap.sock \
 The first argument is the path to the I²C device, and the second is the 7-bit
 hexadecimal device address. The preload library spawns a `socat` helper (looked
 up at `/media/data/socat`) to bridge the proxy socket to the serial device
-specified by `I2C_SOCAT_TTY`.  Start the `tty_tap_server` in another shell and
+specified by `I2C_SOCAT_TTY`. Start the `tty_tap_server` in another shell and
 then run the command above. The utility writes the current time every second
-and expects to read back a line of the form `N: VALUE` where `N` is an
-incrementing counter from the server and `VALUE` is the echoed timestamp.
+and expects to read back 16 bytes: the original timestamp followed by an
+incrementing counter from the server. Both values are printed in decimal when
+received.

--- a/tty_tap_server/README.md
+++ b/tty_tap_server/README.md
@@ -1,8 +1,8 @@
 # tty_tap_server
 
 Simple serial tap server that waits for `/dev/ttyS22` to become available,
-prints any lines received, and echoes each line back with an incrementing
-counter.
+prints any eight-byte timestamp packets received, and echoes the same bytes
+back followed by an incrementing counter encoded as another eight bytes.
 
 When the environment variable `I2C_PROXY_RAW` is set to a non-zero value the
 server switches to raw mode. In this mode serial traffic is expected to be in


### PR DESCRIPTION
## Summary
- Send time writer packets as 8-byte UNIX seconds and parse binary echo plus counter
- Have tty tap server echo the timestamp bytes and append its own 8-byte counter
- Update documentation to reflect the binary protocol

## Testing
- `cargo test --manifest-path i2c_time_writer/Cargo.toml`
- `cargo test --manifest-path tty_tap_server/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68ba0690e110833297241e259e835293