### PR TITLE
Handle JSON in tty tap server

### DIFF
--- a/tty_tap_server/Cargo.lock
+++ b/tty_tap_server/Cargo.lock
@@ -3,5 +3,93 @@
 version = 4
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tty_tap_server"
 version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"

--- a/tty_tap_server/Cargo.toml
+++ b/tty_tap_server/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+serde_json = "1.0"

--- a/tty_tap_server/README.md
+++ b/tty_tap_server/README.md
@@ -1,11 +1,11 @@
 # tty_tap_server
 
-Simple serial tap server that waits for `/dev/ttyS22` to become available,
-prints any eight-byte timestamp packets received, and echoes the same bytes
+Simple serial tap server that waits for `/dev/ttyS22` to become available and
+processes JSON lines produced by the `i2c_redirect` library. For each `write`
+event the hexadecimal payload is decoded, logged as a timestamp, and echoed
 back followed by an incrementing counter encoded as another eight bytes.
 
 When the environment variable `I2C_PROXY_RAW` is set to a non-zero value the
 server switches to raw mode. In this mode serial traffic is expected to be in
 the binary `[addr][cmd][len][data...]` frame format. Each received frame is
-printed as a hexadecimal string and echoed back to the serial device
-unchanged.
+printed as a hexadecimal string and echoed back to the serial device unchanged.


### PR DESCRIPTION
## Summary
- decode hex strings from JSON events
- parse and respond to write events on `/dev/ttyS22`
- document JSON-based behaviour

## Testing
- `cd tty_tap_server && cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ba0862ee5c8332a4274c0d12b2da7f