### PR TITLE
Serialize I2C read/write access

### DIFF
--- a/c_preload_lib/README.md
+++ b/c_preload_lib/README.md
@@ -11,18 +11,9 @@ Cross-compile for aarch64 (requires `aarch64-linux-gnu-gcc` on PATH):
 make CROSS_COMPILE=aarch64-linux-gnu-
 ```
 
-Run (tee mode):
+Run:
 ```bash
 export I2C_PROXY_SOCK=/tmp/i2c.tap.sock
-export I2C_PROXY_PASSTHROUGH=1
-export LD_PRELOAD=$PWD/libi2c_redirect.so
-your_i2c_program
-```
-
-Run (redirect only, no real hardware access):
-```bash
-export I2C_PROXY_SOCK=/tmp/i2c.tap.sock
-unset I2C_PROXY_PASSTHROUGH
 export LD_PRELOAD=$PWD/libi2c_redirect.so
 your_i2c_program
 ```

--- a/scripts/env_i2c_tap_no_passthrough.sh
+++ b/scripts/env_i2c_tap_no_passthrough.sh
@@ -1,19 +1,16 @@
 #!/usr/bin/env bash
 # Configure environment variables to route I²C traffic through the i2c tap
-# server without accessing any real hardware.
+# server without accessing any real hardware.  Passthrough support has been
+# removed so intercepted commands are always proxied.
 #
 # The script should be sourced so that the exports affect the current shell.
 # It defines the following variables:
 #   I2C_PROXY_SOCK     - Unix socket used by the tap server (default: /tmp/i2c.tap.sock)
 #   LD_PRELOAD         - Path to the preload library that intercepts I²C calls
-# The variable I2C_PROXY_PASSTHROUGH is explicitly unset to prevent real bus
-# accesses.  After sourcing this file run the desired I²C program normally and
-# all calls will be forwarded to the tap server.
 
 # Use caller supplied socket path or fall back to the default.
 export I2C_PROXY_SOCK="${I2C_PROXY_SOCK:-/tmp/i2c.tap.sock}"
-# Ensure passthrough is disabled so no real I²C hardware is accessed.
-unset I2C_PROXY_PASSTHROUGH
+# All traffic is automatically proxied; no passthrough variable is needed.
 # Point LD_PRELOAD at the interception library located in the current
 # working directory.  If LD_PRELOAD is already set the existing value is
 # preserved; otherwise a relative path is used so the caller can position
@@ -23,6 +20,5 @@ export LD_PRELOAD="${LD_PRELOAD:-./libi2c_redirect.so}"
 # Provide a brief summary so users know the configuration in effect.
 echo "I2C tap environment configured:"
 echo "  I2C_PROXY_SOCK=$I2C_PROXY_SOCK"
-echo "  I2C_PROXY_PASSTHROUGH is unset"
 echo "  LD_PRELOAD=$LD_PRELOAD"
 

--- a/scripts/env_tty_tap_no_passthrough.sh
+++ b/scripts/env_tty_tap_no_passthrough.sh
@@ -11,8 +11,8 @@
 #   I2C_PROXY_SOCK     - Socket the preload library connects to
 #   LD_PRELOAD         - Path to the preload library
 # If the chosen serial device does not exist a background `socat` process is
-# started to create it.  The script also unsets I2C_PROXY_PASSTHROUGH to
-# prevent access to actual I²C buses.
+# started to create it.  Passthrough support has been removed so intercepted
+# commands are always proxied.
 
 # Serial device used for tapping; override by pre-setting I2C_SOCAT_TTY.
 export I2C_SOCAT_TTY="${I2C_SOCAT_TTY:-/dev/ttyS22}"
@@ -34,8 +34,7 @@ fi
 export I2C_SOCAT_SOCKET="${I2C_SOCAT_SOCKET:-/tmp/ttyS22.tap.sock}"
 # The preload library connects to the same socket exposed by socat.
 export I2C_PROXY_SOCK="$I2C_SOCAT_SOCKET"
-# Disable passthrough so intercepted calls never reach real I²C hardware.
-unset I2C_PROXY_PASSTHROUGH
+# All traffic is automatically proxied; no passthrough variable is required.
 # Point LD_PRELOAD at the interception library located in the current
 # working directory.  Users may override LD_PRELOAD to supply a different
 # path but by default a relative path is used so this script functions in any
@@ -47,6 +46,5 @@ echo "TTY tap environment configured:"
 echo "  I2C_SOCAT_TTY=$I2C_SOCAT_TTY ($I2C_SOCAT_TTY_STATUS)"
 echo "  I2C_SOCAT_SOCKET=$I2C_SOCAT_SOCKET"
 echo "  I2C_PROXY_SOCK=$I2C_PROXY_SOCK"
-echo "  I2C_PROXY_PASSTHROUGH is unset"
 echo "  LD_PRELOAD=$LD_PRELOAD"
 


### PR DESCRIPTION
## Summary
- add global mutex for I2C read/write serialization
- guard read() and write() hooks with mutex to avoid interleaving traffic
- drop passthrough mode so all intercepted I2C operations are proxied

## Testing
- `cd c_preload_lib && make`


------
https://chatgpt.com/codex/tasks/task_e_68bb1610f2348332b5fbe88c8e8149b3