### PR TITLE
Send read requests and read full responses

### DIFF
--- a/c_preload_lib/Makefile
+++ b/c_preload_lib/Makefile
@@ -6,8 +6,10 @@ CROSS_COMPILE ?=
 CC = $(CROSS_COMPILE)gcc
 # Default to building an optimized shared library without debug asserts.
 # Users can supply their own CFLAGS to adjust optimization levels.
-CFLAGS ?= -O2 -DNDEBUG -fPIC -Wall -Wextra
-LDFLAGS ?= -shared -ldl
+# Threaded operations require pthread support for mutex locking around the
+# proxy socket.
+CFLAGS ?= -O2 -DNDEBUG -fPIC -Wall -Wextra -pthread
+LDFLAGS ?= -shared -ldl -pthread
 TARGET := libi2c_redirect.so
 SRC := i2c_redirect.c
 


### PR DESCRIPTION
## Summary
- Serialize socket access with a mutex and log I²C read requests
- Loop `recv` until the requested length is satisfied or an error occurs
- Link preload library with pthread for thread-safe socket handling

## Testing
- `make c_preload_lib`


------
https://chatgpt.com/codex/tasks/task_e_68bb182891248332bb8f93089f95b230