### PR TITLE
Use fixed-length I2C command frames

### DIFF
--- a/c_preload_lib/README.md
+++ b/c_preload_lib/README.md
@@ -31,10 +31,12 @@ defaults when they are unset:
 
 ### Data format
 
-The library always emits binary `[addr][cmd][len][data...]` frames. Tools
-consuming the stream must interpret the framing accordingly. For read requests
-(`cmd == 1`) no payload bytes follow and `len` conveys the number of bytes the
-caller expects to read in response.
+The library always emits fixed-size ten-byte frames formatted as
+`[addr][cmd][d0]...[d7]`. The `cmd` byte is `0` for write operations and
+`READ_COMMAND` for read requests. Write frames transmit the eight data bytes
+verbatim so consumers can observe the payload. Read frames ignore the data
+section (which is typically all zeros) and cause the tap server to return a
+62-byte response.
 
 ### Optional serial forwarding via socat
 

--- a/tty_tap_server/README.md
+++ b/tty_tap_server/README.md
@@ -1,7 +1,7 @@
 # tty_tap_server
 
 Simple serial tap server that waits for `/dev/ttyS22` to become available and
-processes raw `[addr][cmd][len][data...]` frames produced by the `i2c_redirect`
+processes raw `[addr][cmd][d0]...[d7]` frames produced by the `i2c_redirect`
 library. Write frames are logged in hexadecimal, while read frames cause the
-server to log the request and return an incrementing counter truncated or
-padded to the requested length.
+server to log the request and return a 62-byte response containing an
+incrementing counter padded with zeros.


### PR DESCRIPTION
## Summary
- remove variable-length field from I²C framing
- read hook now requests data with a single command frame
- tap server parses ten-byte commands and replies with 62-byte payloads

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68bf112efb6c83328a76edfe11d14109