### PR TITLE
Add non-blocking test client for TCP server

### DIFF
--- a/tcp_server/Cargo.lock
+++ b/tcp_server/Cargo.lock
@@ -3,14 +3,348 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "2.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "cc"
+version = "1.2.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "ctrlc"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881c5d0a13b2f1498e2306e82cbada78390e152d4b1378fb28a84f4dcd0dc4f3"
+dependencies = [
+ "dispatch",
+ "nix",
+ "windows-sys",
+]
+
+[[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
+name = "log"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "syn"
+version = "2.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tcp_server"
 version = "0.1.0"
 dependencies = [
+ "chrono",
+ "ctrlc",
  "libc",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link",
 ]

--- a/tcp_server/Cargo.toml
+++ b/tcp_server/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2024"
 
 [dependencies]
 libc = "0.2"
+chrono = { version = "0.4", default-features = true }
+ctrlc = "3"

--- a/tcp_server/src/bin/test_client.rs
+++ b/tcp_server/src/bin/test_client.rs
@@ -1,0 +1,329 @@
+//! Minimal TCP test client used to exercise the echo server during
+//! development.
+//!
+//! The binary continuously attempts to connect to the server, transmits the
+//! current UTC timestamp every second and prints the echoed responses. The
+//! implementation mirrors the non-blocking approach used by the server so
+//! behaviour is deterministic and resilient to unexpected network stalls. The
+//! code contains extensive commentary to comply with the repository
+//! documentation requirements and to clarify the rationale behind each step of
+//! the client state machine.
+
+use std::env;
+use std::io::{self, ErrorKind, Read, Write};
+use std::net::TcpStream;
+use std::os::unix::io::AsRawFd;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Duration;
+
+use chrono::{SecondsFormat, Utc};
+
+/// Default TCP endpoint used when no explicit address is provided on the
+/// command line. The chosen port is arbitrary but avoids well-known services so
+/// it is unlikely to clash with system daemons during development.
+const DEFAULT_SERVER_ADDR: &str = "127.0.0.1:4000";
+
+/// Timeout applied to all socket readiness checks. The value matches the
+/// requirements stated by the user request and ensures the client does not
+/// block indefinitely when the server becomes unresponsive.
+const IO_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// Delay applied between reconnection attempts. A short pause prevents the
+/// client from busy-looping when the server is temporarily unavailable while
+/// still providing quick recovery once it comes back online.
+const RECONNECT_DELAY: Duration = Duration::from_secs(1);
+
+fn main() {
+    // Determine the destination address. The first command line argument takes
+    // precedence while falling back to [`DEFAULT_SERVER_ADDR`] keeps the binary
+    // ergonomic for local development sessions.
+    let server_addr = env::args()
+        .nth(1)
+        .unwrap_or_else(|| DEFAULT_SERVER_ADDR.to_string());
+
+    // Shared flag toggled by the Ctrl+C handler. Each loop iteration checks the
+    // flag to decide whether the program should continue running.
+    let running = Arc::new(AtomicBool::new(true));
+    let signal_flag = running.clone();
+    if let Err(err) = ctrlc::set_handler(move || {
+        // Mark the program as finished and provide visual feedback so the user
+        // knows the interrupt request was received.
+        signal_flag.store(false, Ordering::SeqCst);
+        println!("Received interrupt, shutting down client...");
+    }) {
+        eprintln!("Failed to install Ctrl+C handler: {err}");
+        return;
+    }
+
+    println!("Starting TCP test client. Connecting to {server_addr}...");
+
+    // Run the connection loop and surface any terminal error to the user.
+    if let Err(err) = client_loop(&server_addr, &running) {
+        if err.kind() != ErrorKind::Interrupted {
+            eprintln!("Client terminated due to unrecoverable error: {err}");
+        }
+    }
+
+    println!("Client exited cleanly");
+}
+
+/// Primary control loop that manages the connection lifecycle.
+///
+/// The function repeatedly tries to connect to the server, processes the
+/// established session and handles transient failures by reconnecting after a
+/// short delay. The loop terminates when the shared `running` flag is toggled by
+/// the Ctrl+C handler.
+fn client_loop(server_addr: &str, running: &Arc<AtomicBool>) -> io::Result<()> {
+    while running.load(Ordering::SeqCst) {
+        match TcpStream::connect(server_addr) {
+            Ok(stream) => {
+                println!("Connected to {server_addr}");
+
+                // Delegate the non-blocking communication to a helper. Any
+                // timeout or connection error is logged before attempting to
+                // reconnect.
+                match handle_connection(stream, running) {
+                    Ok(()) => {
+                        // Normal termination means the Ctrl+C handler asked the
+                        // loop to stop. Break early to avoid an unnecessary
+                        // reconnect delay.
+                        break;
+                    }
+                    Err(err) if err.kind() == ErrorKind::Interrupted => {
+                        break;
+                    }
+                    Err(err) if err.kind() == ErrorKind::TimedOut => {
+                        eprintln!("Communication with {server_addr} timed out. Reconnecting...");
+                    }
+                    Err(err) => {
+                        eprintln!("Connection to {server_addr} failed: {err}");
+                    }
+                }
+            }
+            Err(err) => {
+                eprintln!("Unable to connect to {server_addr}: {err}");
+            }
+        }
+
+        // Honour the shutdown request immediately without waiting for the delay
+        // when the user pressed Ctrl+C while the connection was down.
+        if !running.load(Ordering::SeqCst) {
+            break;
+        }
+
+        // Pause briefly before the next attempt to avoid hammering the server
+        // when repeated failures occur.
+        sleep_with_checks(running, RECONNECT_DELAY);
+    }
+
+    Ok(())
+}
+
+/// Handle an established TCP session using non-blocking I/O.
+///
+/// The function configures the socket for non-blocking mode, sends the current
+/// UTC timestamp once per second and reads back responses until an error is
+/// observed or the user aborts the program. Any error is surfaced to the caller
+/// so the connection loop can decide whether to reconnect or shut down.
+fn handle_connection(mut stream: TcpStream, running: &Arc<AtomicBool>) -> io::Result<()> {
+    stream.set_nonblocking(true)?;
+    let fd = stream.as_raw_fd();
+
+    // Buffer used to accumulate incoming bytes until a newline is observed. The
+    // buffer is reused across iterations to avoid reallocations in the steady
+    // state.
+    let mut inbound = Vec::with_capacity(256);
+
+    while running.load(Ordering::SeqCst) {
+        let timestamp = format_current_utc();
+        let mut payload = timestamp.as_bytes();
+
+        // Send the newline-terminated timestamp to the server, waiting for the
+        // socket to become writable before each write attempt.
+        while !payload.is_empty() {
+            if wait_for_fd_event(fd, libc::POLLOUT, IO_TIMEOUT)?.is_none() {
+                return Err(io::Error::new(
+                    ErrorKind::TimedOut,
+                    "timed out waiting for socket to become writable",
+                ));
+            }
+
+            match stream.write(payload) {
+                Ok(0) => {
+                    return Err(io::Error::new(
+                        ErrorKind::WriteZero,
+                        "socket closed while sending timestamp",
+                    ));
+                }
+                Ok(bytes_written) => {
+                    payload = &payload[bytes_written..];
+                }
+                Err(ref err) if err.kind() == ErrorKind::WouldBlock => {
+                    // The socket reported readiness but produced a `WouldBlock`
+                    // error. Retry the write after the next poll cycle.
+                    continue;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+
+        // Retrieve and print the echoed response. The helper returns an error
+        // whenever the server closes the connection or the 100 ms timeout is
+        // reached.
+        let response = read_line_nonblocking(&mut stream, fd, running, &mut inbound)?;
+        println!("Server replied: {response}");
+
+        // Wait for roughly one second before sending the next timestamp. The
+        // helper allows the loop to observe Ctrl+C quickly even while waiting.
+        sleep_with_checks(running, Duration::from_secs(1));
+    }
+
+    Ok(())
+}
+
+/// Wait for the provided file descriptor to become ready for the specified
+/// events using `poll`.
+///
+/// The helper returns `Ok(None)` when the timeout expires, `Ok(Some(_))` when an
+/// event occurs and propagates any fatal poll error.
+fn wait_for_fd_event(
+    fd: libc::c_int,
+    events: libc::c_short,
+    timeout: Duration,
+) -> io::Result<Option<libc::c_short>> {
+    let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as libc::c_int;
+    let mut poll_fd = libc::pollfd {
+        fd,
+        events,
+        revents: 0,
+    };
+
+    loop {
+        // SAFETY: the pollfd structure references stack memory that stays alive
+        // for the duration of the call, making the pointer passed to `poll`
+        // valid. Only one file descriptor is monitored, therefore the call is
+        // straightforward.
+        let rc = unsafe { libc::poll(&mut poll_fd, 1, timeout_ms) };
+
+        if rc < 0 {
+            let err = io::Error::last_os_error();
+            if err.kind() == ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(err);
+        } else if rc == 0 {
+            return Ok(None);
+        }
+
+        // Surface hang-ups and generic socket errors as explicit I/O errors so
+        // the caller can attempt a clean reconnection.
+        if poll_fd.revents & libc::POLLERR != 0 {
+            return Err(io::Error::new(
+                ErrorKind::Other,
+                "socket error reported by poll",
+            ));
+        }
+        if poll_fd.revents & libc::POLLHUP != 0 {
+            return Err(io::Error::new(
+                ErrorKind::UnexpectedEof,
+                "remote side closed the connection",
+            ));
+        }
+        if poll_fd.revents & libc::POLLNVAL != 0 {
+            return Err(io::Error::new(
+                ErrorKind::Other,
+                "invalid file descriptor for poll",
+            ));
+        }
+
+        return Ok(Some(poll_fd.revents));
+    }
+}
+
+/// Read a single newline-terminated line using non-blocking operations.
+fn read_line_nonblocking(
+    stream: &mut TcpStream,
+    fd: libc::c_int,
+    running: &Arc<AtomicBool>,
+    inbound: &mut Vec<u8>,
+) -> io::Result<String> {
+    loop {
+        if !running.load(Ordering::SeqCst) {
+            return Err(io::Error::new(
+                ErrorKind::Interrupted,
+                "client shutdown requested",
+            ));
+        }
+
+        if wait_for_fd_event(fd, libc::POLLIN, IO_TIMEOUT)?.is_none() {
+            return Err(io::Error::new(
+                ErrorKind::TimedOut,
+                "timed out waiting for data from server",
+            ));
+        }
+
+        let mut buf = [0u8; 512];
+        match stream.read(&mut buf) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    ErrorKind::UnexpectedEof,
+                    "server closed the connection",
+                ));
+            }
+            Ok(bytes_read) => {
+                inbound.extend_from_slice(&buf[..bytes_read]);
+                if let Some(position) = inbound.iter().position(|&b| b == b'\n') {
+                    let raw_line = inbound.drain(..=position).collect::<Vec<u8>>();
+                    match String::from_utf8(raw_line) {
+                        Ok(mut text) => {
+                            if !text.is_empty() && text.ends_with('\n') {
+                                // Trim the newline delimiter because `println!`
+                                // appends its own line ending.
+                                text.pop();
+                            }
+                            return Ok(text);
+                        }
+                        Err(err) => {
+                            return Err(io::Error::new(ErrorKind::InvalidData, err));
+                        }
+                    }
+                }
+            }
+            Err(ref err) if err.kind() == ErrorKind::WouldBlock => {
+                continue;
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+/// Convert the current system time to an RFC 3339 UTC string with millisecond
+/// precision. A trailing newline is appended so the server can treat the value
+/// as a line-based protocol message.
+fn format_current_utc() -> String {
+    let now = Utc::now();
+    let mut formatted = now.to_rfc3339_opts(SecondsFormat::Millis, true);
+    formatted.push('\n');
+    formatted
+}
+
+/// Sleep for the requested duration while periodically checking whether the
+/// user requested shutdown. The helper ensures the client reacts quickly to
+/// Ctrl+C even when paused between transmissions.
+fn sleep_with_checks(running: &Arc<AtomicBool>, total: Duration) {
+    let mut remaining = total;
+    let check_interval = Duration::from_millis(100);
+
+    while remaining > Duration::ZERO && running.load(Ordering::SeqCst) {
+        let step = if remaining > check_interval {
+            check_interval
+        } else {
+            remaining
+        };
+
+        thread::sleep(step);
+        remaining = remaining.saturating_sub(step);
+    }
+}


### PR DESCRIPTION
## Summary
- add dependencies required for signal handling and timestamp formatting
- implement a Ctrl+C aware TCP test client that sends UTC timestamps and prints responses using non-blocking I/O with a 100ms timeout

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68d1515ba91c8332afc16dd6ae393af0